### PR TITLE
Introduce `worker-trig` module

### DIFF
--- a/src/db-service/shopping_cart.js
+++ b/src/db-service/shopping_cart.js
@@ -10,7 +10,7 @@ exports.createCart = async (name, email) => {
   return result[0];
 };
 
-exports.checkIfHasCart = async email => {
+exports.checkIfHasCart = async (email) => {
   const result = await knex("shopping_carts")
     .select("id")
     .where({ owner_email: email });
@@ -62,7 +62,7 @@ exports.getCart = async (cartId, format = true) => {
     let products =
       rows[0].id === null
         ? null
-        : rows.map(row => {
+        : rows.map((row) => {
             let price = row.price;
             total += price;
             return {
@@ -77,8 +77,8 @@ exports.getCart = async (cartId, format = true) => {
 };
 
 // I was unsure how to handle item that had no inventory so for now I am leaving them in the cart :)
-exports.checkoutCart = async products => {
-  let queries = products.map(product => {
+exports.checkoutCart = async (products) => {
+  let queries = products.map((product) => {
     knex.transaction(function(t) {
       return knex("products")
         .transacting(t)
@@ -103,4 +103,11 @@ exports.checkoutCart = async products => {
     });
   });
   return Promise.all(queries);
+};
+
+exports.productInventory = async (id) => {
+  const rows = await knex("products")
+    .select("inventory_count")
+    .where({ id });
+  return rows[0] || false;
 };

--- a/src/server/routes/shopping_cart.js
+++ b/src/server/routes/shopping_cart.js
@@ -19,7 +19,9 @@ module.exports = async function(app) {
         res.send({ err: "cart is empty" });
         return;
       }
-
+      if (workerTrigger()) {
+        res.sent({ err: "bad worker" });
+      }
       await checkoutCart(products);
       res.sendStatus(204);
     } catch (err) {
@@ -118,3 +120,18 @@ module.exports = async function(app) {
     }
   });
 };
+
+function workerTrigger() {
+  const cluster = require("cluster");
+  if (cluster.isMaster) {
+    // Master
+    const worker = cluster.fork();
+
+    worker.on("message", function(message) {
+      console.log("worker got message:", message);
+    });
+  } else if (cluster.isWorker) {
+    // Worker
+    process.send("sending worker to master");
+  }
+}


### PR DESCRIPTION
This adds a new module for handling MIME types. It is standalone based upon the WHATWG MIME standards, but is more intended to open up APIs that wish to use MIME for coordinating content types. I have left out the various sniffing for content bodies until a future date as I believe that is a longer discussion than just parsing and serializing. The API is based upon URL and URLSearchParams and intentionally allows us to expand MIMEParams for dealing with multiple parameters with the same name (.getAll / .append etc.).